### PR TITLE
[INFR-3167] print the reason why the test fails

### DIFF
--- a/terraform-fmt/exec/wrapper-terraform-fmt.sh
+++ b/terraform-fmt/exec/wrapper-terraform-fmt.sh
@@ -9,7 +9,7 @@ while IFS= read -r FILE; do
 done < _TERRAFORM_LIST
 
 if [[ -f "_TERRAFORM_DIFF" ]]; then
-  echo -e "Diff: \n${DIFF}"
+  echo -e "Diff: \n${_TERRAFORM_DIFF}"
   reviewdog -f=diff -name="terraform fmt" -reporter=github-pr-review < _TERRAFORM_DIFF
   exit 1
 fi

--- a/terraform-fmt/exec/wrapper-terraform-fmt.sh
+++ b/terraform-fmt/exec/wrapper-terraform-fmt.sh
@@ -9,6 +9,7 @@ while IFS= read -r FILE; do
 done < _TERRAFORM_LIST
 
 if [[ -f "_TERRAFORM_DIFF" ]]; then
+  echo -e "Diff: \n ${DIFF}"
   reviewdog -f=diff -name="terraform fmt" -reporter=github-pr-review < _TERRAFORM_DIFF
   exit 1
 fi

--- a/terraform-fmt/exec/wrapper-terraform-fmt.sh
+++ b/terraform-fmt/exec/wrapper-terraform-fmt.sh
@@ -9,7 +9,7 @@ while IFS= read -r FILE; do
 done < _TERRAFORM_LIST
 
 if [[ -f "_TERRAFORM_DIFF" ]]; then
-  echo -e "Diff: \n ${DIFF}"
+  echo -e "Diff: \n${DIFF}"
   reviewdog -f=diff -name="terraform fmt" -reporter=github-pr-review < _TERRAFORM_DIFF
   exit 1
 fi


### PR DESCRIPTION
This fails with no output for me and I am unable to replicate with 'terraform fmt' on my local machine.  Adding some output in hopes of learning why it's failing.